### PR TITLE
Begone dildo

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -149,44 +149,6 @@
       weight: 2
     - id: ClothingHandsKnuckleDustersSyndicate
 
-
-- type: entityTable # Floof - Start
-  id: LewdMaintLoot
-  table: !type:GroupSelector
-    children:
-    - id: LewdWand
-    - id: LewdVibeGreen
-    - id: LewdVibeTeal
-    - id: LewdVibePink
-    - id: LewdVibeRed
-    - id: LewdVibeYellow
-    - id: LewdFleshlightGreen
-    - id: LewdFleshlightTeal
-    - id: LewdFleshlightPink
-    - id: LewdFleshlightRed
-    - id: LewdFleshlightYellow
-    - id: AvianDildo
-    - id: CanineDildo
-    - id: CanineDildoRed
-    - id: HorseDildo
-    - id: DragonDildo
-    - id: NormalDildo
-    - id: TentacleDildo
-    - id: DoubleDildo
-    - id: WhipPink
-      weight: 0.5
-    - id: WhipTeal
-      weight: 0.5
-    - id: WhipPinkCrotch
-      weight: 0.5
-    - id: WhipTealCrotch
-      weight: 0.5
-    - id: SpankPinkPaddle
-      weight: 0.5
-    - id: SpankTealPaddle
-      weight: 0.5
-    # Floof - End
-
 - type: entityTable
   id: MaintenanceLockerLoot
   table: !type:AllSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -184,11 +184,6 @@
 #    - id: ClosetMaintenanceFilledRandom # Frontier: don't trust this
 #      prob: 0.01 # Frontier: don't trust this
     # Lewd - Floof
-    - !type:NestedSelector
-      tableId: LewdMaintLoot
-      prob: 0.15
-      rolls: !type:RangeNumberSelector
-        range: 1, 2
 
 - type: entity
   id: ClosetMaintenanceFilledRandom

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -6,6 +6,7 @@
   suffix: 20 TC
   description: It seems to be pulsing with suspiciously enticing energies.
   components:
+  - type: NFCoin
   - type: Sprite
     sprite: Objects/Specific/Syndicate/telecrystal.rsi
     state: telecrystal

--- a/Resources/Prototypes/_AS/Entities/Objects/Specifics/mercenary.yml
+++ b/Resources/Prototypes/_AS/Entities/Objects/Specifics/mercenary.yml
@@ -5,6 +5,7 @@
   suffix: 20 MC
   description: A plastic chip given from Expeditionary rewards for Mercenaries for their hard work. It can be exchanged at a Mercenary Vending Machine for a variety of items.
   components:
+  - type: NFCoin
   - type: Sprite
     sprite: _AS/Objects/Specific/Mercenary/merc_coin.rsi
     state: merc_coin


### PR DESCRIPTION
Deleted the LewdMaintLoot entity table and its associated items from the lockers misc.yml prototype catalog.
Added the NFCoin component to the syndicate telecrystal and mercenary coin entities to support new coin functionality, should now be able to be stowed in wallets. Also removed LewdMaintLoot from locker misc fill table, so no errors there now.

known bug: Hovering the crystals/coins over the wallet will result in a red ghost effect as though they can't be inserted, they still will.